### PR TITLE
Fix Clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "dagster_pipes_rust"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "flate2",


### PR DESCRIPTION
Hey Colton! Don't mind me contributing to this project — but have been itching to apply it 😃 
I'm not an expert at Rust per se, and am learning as I go as well, so I may make mistakes — don't hesitate to ask lots of questions in reviews.

This will be the first of few PRs from me.

---

In this PR, warnings from Clippy are applied, except for unused fields and methods.

High-level changes include:
- Swapping `base64.decode` (deprecated) with `BASE64_STANDARD.decode` per their [docs](https://docs.rs/base64/latest/base64/#encoding-alphabet). 
- Removing `.write` from the `OpenOptions` builder as it's redundant given `.append`
- Unwrapping `write!`'s `Result` return value
- Returning expressions from functions by omitting `return` and `;`
