### PR TITLE
♻️ Implement `PipesContextLoader` and `PipesParamsLoader` as traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +43,24 @@ dependencies = [
  "flate2",
  "serde",
  "serde_json",
+ "tempfile",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "flate2"
@@ -56,6 +79,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "libc"
+version = "0.2.167"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +104,12 @@ checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "proc-macro2"
@@ -86,6 +127,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -138,7 +192,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "dagster_pipes_rust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0"
 flate2 = "1"
+
+[dev-dependencies]
+tempfile = "3.14.0"

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.lock
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "dagster_pipes_rust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64",
  "flate2",

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.toml
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.toml
@@ -6,5 +6,3 @@ edition = "2021"
 [dependencies]
 dagster_pipes_rust = { path = "../.." }
 serde_json = "1.0.133"
-
-

--- a/src/context_loader.rs
+++ b/src/context_loader.rs
@@ -24,15 +24,90 @@ impl PipesDefaultContextLoader {
 
 impl PipesContextLoader for PipesDefaultContextLoader {
     fn load_context(&self, params: Map<String, Value>) -> PipesContextData {
+        // TODO: Have this function return a `Result<PipesContextData>` instead
         const FILE_PATH_KEY: &str = "path";
         const DIRECT_KEY: &str = "data";
 
         match (params.get(FILE_PATH_KEY), params.get(DIRECT_KEY)) {
-            (Some(Value::String(string)), None) => from_str(string).unwrap(),
+            // `_` in second-half of tuple to account for the case where both keys are specified
+            (Some(Value::String(path)), _) => {
+                from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+            }
             (None, Some(Value::Object(map))) => from_value(Value::Object(map.clone())).unwrap(),
-            _ => panic!("Invalid params provided"), // TODO: Have this function return a Result
+            _ => {
+                panic!(
+                    "Invalid params, expected key \"{}\" or \"{}\", received {:?}",
+                    FILE_PATH_KEY, DIRECT_KEY, params
+                )
+            }
         }
     }
 }
 
-// TODO: Unit tests
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::io::Write;
+
+    use serde_json::json;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_load_context_from_data_dict() {
+        let default_context_loader = PipesDefaultContextLoader::new();
+        let params = json!({"data": {"asset_keys": ["asset1", "asset2"], "run_id": "0123456", "extras": {"key": "value"}}});
+        let params = params.as_object().expect("Invalid raw JSON provided");
+        assert_eq!(
+            default_context_loader.load_context(params.clone()),
+            PipesContextData {
+                asset_keys: Some(vec!["asset1".to_string(), "asset2".to_string()]),
+                run_id: "0123456".to_string(),
+                extras: HashMap::from([("key".to_string(), Value::String("value".to_string()))])
+            }
+        );
+    }
+
+    #[test]
+    fn test_load_context_from_file_path() {
+        // TODO: This is an integration test (interacting with the filesystem)
+        //       Mock the implementation instead.
+        let default_context_loader = PipesDefaultContextLoader::new();
+        let mut file = NamedTempFile::new().expect("Failed to create tempfile for testing");
+        file.write_all(r#"{"asset_keys": ["asset1", "asset2"], "run_id": "0123456", "extras": {"key": "value"}}"#.as_bytes()).expect("Failed to write data into tempfile");
+
+        let params = json!({"path": file.path()});
+        let params = params.as_object().unwrap();
+        assert_eq!(
+            default_context_loader.load_context(params.clone()),
+            PipesContextData {
+                asset_keys: Some(vec!["asset1".to_string(), "asset2".to_string()]),
+                run_id: "0123456".to_string(),
+                extras: HashMap::from([("key".to_string(), Value::String("value".to_string()))])
+            }
+        );
+    }
+
+    /// Mimics behaviour on Python side
+    #[test]
+    fn test_load_context_prioritizes_file_path_when_both_are_present() {
+        let default_context_loader = PipesDefaultContextLoader::new();
+        let mut file = NamedTempFile::new().expect("Failed to create tempfile for testing");
+        file.write_all(r#"{"asset_keys": ["asset_from_path"], "run_id": "id_from_path", "extras": {"key_from_path": "value_from_path"}}"#.as_bytes()).expect("Failed to write data into tempfile");
+
+        let params = json!({"data": {"asset_keys": ["asset_from_data"], "run_id": "id_from_data", "extras": {"key_from_data": "value_from_data"}}, "path": file.path()});
+        let params = params.as_object().unwrap();
+        assert_eq!(
+            default_context_loader.load_context(params.clone()),
+            PipesContextData {
+                asset_keys: Some(vec!["asset_from_path".to_string()]),
+                run_id: "id_from_path".to_string(),
+                extras: HashMap::from([(
+                    "key_from_path".to_string(),
+                    Value::String("value_from_path".to_string())
+                )])
+            }
+        );
+    }
+}

--- a/src/context_loader.rs
+++ b/src/context_loader.rs
@@ -1,0 +1,38 @@
+use serde_json::{from_str, from_value, Map, Value};
+
+use crate::PipesContextData;
+
+pub trait PipesContextLoader {
+    fn load_context(&self, params: Map<String, Value>) -> PipesContextData;
+}
+
+/// Context loader that loads context data from either a file or directly from the provided params.
+///
+/// The location of the context data is configured by the params received by the loader. If the params
+/// include a key `path`, then the context data will be loaded from a file at the specified path. If
+/// the params instead include a key `data`, then the corresponding value should be a dict
+/// representing the context data.
+/// Translation of https://github.com/dagster-io/dagster/blob/258d9ca0db7fcc16d167e55fee35b3cf3f125b2e/python_modules/dagster-pipes/dagster_pipes/__init__.py#L604-L630
+#[derive(Debug, Default)]
+pub struct PipesDefaultContextLoader;
+
+impl PipesDefaultContextLoader {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PipesContextLoader for PipesDefaultContextLoader {
+    fn load_context(&self, params: Map<String, Value>) -> PipesContextData {
+        const FILE_PATH_KEY: &str = "path";
+        const DIRECT_KEY: &str = "data";
+
+        match (params.get(FILE_PATH_KEY), params.get(DIRECT_KEY)) {
+            (Some(Value::String(string)), None) => from_str(string).unwrap(),
+            (None, Some(Value::Object(map))) => from_value(Value::Object(map.clone())).unwrap(),
+            _ => panic!("Invalid params provided"), // TODO: Have this function return a Result
+        }
+    }
+}
+
+// TODO: Unit tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,17 @@
+mod context_loader;
+mod params_loader;
+
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
 
-use context_loader::PipesContextLoader;
-use context_loader::PipesDefaultContextLoader;
-use params_loader::PipesEnvVarParamsLoader;
-use params_loader::PipesParamsLoader;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-mod context_loader;
-mod params_loader;
+use crate::context_loader::PipesContextLoader;
+use crate::context_loader::PipesDefaultContextLoader;
+use crate::params_loader::PipesEnvVarParamsLoader;
+use crate::params_loader::PipesParamsLoader;
 
 // partial translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L94-L108

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod params_loader;
 
 // partial translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L94-L108
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 pub struct PipesContextData {
     asset_keys: Option<Vec<String>>,
     run_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,21 @@
 use std::collections::HashMap;
-use std::env;
 use std::fs::OpenOptions;
-use std::io::prelude::*;
 use std::io::Write;
 
-use base64::prelude::*;
-use flate2::read::ZlibDecoder;
-use serde::{de, Deserialize, Serialize};
+use context_loader::PipesContextLoader;
+use context_loader::PipesDefaultContextLoader;
+use params_loader::PipesEnvVarParamsLoader;
+use params_loader::PipesParamsLoader;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-// translation of
-// https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L354-L367
-fn decode_env_var<T>(param: &str) -> T
-where
-    T: de::DeserializeOwned,
-{
-    let zlib_compressed_slice = BASE64_STANDARD.decode(param).unwrap();
-    let mut decoder = ZlibDecoder::new(&zlib_compressed_slice[..]);
-    let mut json_str = String::new();
-    decoder.read_to_string(&mut json_str).unwrap();
-    serde_json::from_str(&json_str).unwrap()
-}
+mod context_loader;
+mod params_loader;
 
 // partial translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L94-L108
 #[derive(Debug, Deserialize)]
-struct PipesContextData {
+pub struct PipesContextData {
     asset_keys: Option<Vec<String>>,
     run_id: String,
     extras: HashMap<String, serde_json::Value>,
@@ -120,12 +110,6 @@ impl PipesFileMessageWriter {
 }
 
 #[derive(Debug, Deserialize)]
-struct PipesContextParams {
-    data: Option<PipesContextData>, // direct in env var
-    path: Option<String>,           // load from file (unsupported)
-}
-
-#[derive(Debug, Deserialize)]
 struct PipesMessagesParams {
     path: Option<String>,  // write to file
     stdio: Option<String>, // stderr | stdout (unsupported)
@@ -134,25 +118,20 @@ struct PipesMessagesParams {
 // partial translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L798-L838
 pub fn open_dagster_pipes() -> PipesContext {
-    // approximation of PipesEnvVarParamsLoader
-    let context_env_var = env::var("DAGSTER_PIPES_CONTEXT").unwrap();
-    let context_params: PipesContextParams = decode_env_var(&context_env_var);
-    let context_data = context_params
-        .data
-        .expect("Unable to load dagster pipes context, only direct env var data supported.");
+    let params_loader = PipesEnvVarParamsLoader::new();
+    let context_loader = PipesDefaultContextLoader::new();
 
-    let msg_env_var = env::var("DAGSTER_PIPES_MESSAGES").unwrap();
-    let messages_params: PipesMessagesParams = decode_env_var(&msg_env_var);
-    let path = messages_params.path.expect(
-        "Unable to write Dagster messages, only temporary file message writing is supported.",
-    );
+    let context_params = params_loader.load_context_params();
+    let message_params = params_loader.load_message_params();
+
+    let path = "path".to_string(); // Placeholder variable until MessageWriter is implemented
 
     //if stdio != "stderr" {
     //    panic!("only stderr supported for dagster pipes messages")
     //}
 
     PipesContext {
-        data: context_data,
+        data: context_loader.load_context(context_params),
         writer: PipesFileMessageWriter { path },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_json::Value;
 
 use crate::context_loader::PipesContextLoader;
 use crate::context_loader::PipesDefaultContextLoader;
@@ -125,7 +126,11 @@ pub fn open_dagster_pipes() -> PipesContext {
     let context_params = params_loader.load_context_params();
     let message_params = params_loader.load_message_params();
 
-    let path = "path".to_string(); // Placeholder variable until MessageWriter is implemented
+    // TODO: Refactor into MessageWriter impl
+    let path = match &message_params["path"] {
+        Value::String(string) => string.clone(),
+        _ => panic!("Expected message \"path\" in bootstrap payload"),
+    };
 
     //if stdio != "stderr" {
     //    panic!("only stderr supported for dagster pipes messages")

--- a/src/params_loader.rs
+++ b/src/params_loader.rs
@@ -1,0 +1,59 @@
+use base64::prelude::*;
+use flate2::read::ZlibDecoder;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+use std::io::Read;
+
+/// Load params passed from the orchestration process by the context injector and
+/// message reader. These params are used to respectively bootstrap the
+/// [`PipesContextLoader`] and [`PipesMessageWriter`].
+pub trait PipesParamsLoader {
+    /// Whether or not this process has been provided with provided with information
+    /// to create a PipesContext or should instead return a mock.
+    fn is_dagster_pipes_process(&self) -> bool;
+    /// Load params passed by the orchestration-side context injector.
+    fn load_context_params(&self) -> Map<String, Value>;
+    /// Load params passed by the orchestration-side message reader.
+    fn load_message_params(&self) -> Map<String, Value>;
+}
+
+// translation of
+// https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L354-L367
+fn decode_env_var<T>(param: &str) -> T
+where
+    T: DeserializeOwned,
+{
+    let zlib_compressed_slice = BASE64_STANDARD.decode(param).unwrap();
+    let mut decoder = ZlibDecoder::new(&zlib_compressed_slice[..]);
+    let mut json_str = String::new();
+    decoder.read_to_string(&mut json_str).unwrap();
+    serde_json::from_str(&json_str).unwrap()
+}
+
+const DAGSTER_PIPES_CONTEXT_ENV_VAR: &str = "DAGSTER_PIPES_CONTEXT";
+const DAGSTER_PIPES_MESSAGES_ENV_VAR: &str = "DAGSTER_PIPES_MESSAGES";
+
+#[derive(Debug, Default)]
+pub struct PipesEnvVarParamsLoader;
+
+impl PipesEnvVarParamsLoader {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PipesParamsLoader for PipesEnvVarParamsLoader {
+    fn is_dagster_pipes_process(&self) -> bool {
+        std::env::var(DAGSTER_PIPES_CONTEXT_ENV_VAR).is_ok()
+    }
+
+    fn load_context_params(&self) -> Map<String, Value> {
+        let param = std::env::var(DAGSTER_PIPES_CONTEXT_ENV_VAR).unwrap();
+        decode_env_var(&param)
+    }
+
+    fn load_message_params(&self) -> Map<String, Value> {
+        let param = std::env::var(DAGSTER_PIPES_MESSAGES_ENV_VAR).unwrap();
+        decode_env_var(&param)
+    }
+}


### PR DESCRIPTION
Mirror Python's `PipesContextLoader` and `PipesParamsLoader` ABC implementations as Rust traits. 

We also define:
- `PipesDefaultContextLoader` to implement `PipesContextLoader` with net new implementation
- `PipesEnvVarParamsLoader` to implement `PipesParamsLoader` with logic refactored from `lib.rs`

### TODO:
Unit tests for:
- [x] `PipesDefaultContextLoader`
- [ ] `PipesEnvVarParamsLoader`

> [!NOTE]
> To be reviewed after #2 
