### PR TITLE
Inital setup of jsonschema & quicktype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "dagster_pipes_rust"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -68,3 +68,16 @@ defs = dg.Definitions(
     },
 )
 ```
+
+
+## Contributing
+
+### Pipes Schema
+
+We use [jsonschema](https://json-schema.org/) to define the pipes protocol and [quicktype](https://quicktype.io/) to generate the Rust structs. Currently, the json schemas live in `jsonschema/pipes` but they should be hosted/defined in a centralized repository in the future.
+
+To generate the Rust structs, make sure to install quicktype with `npm install -g quicktype`. Then run:
+
+```bash
+./quicktype.sh
+```

--- a/jsonschema/pipes/PipesContextData.schema.json
+++ b/jsonschema/pipes/PipesContextData.schema.json
@@ -1,78 +1,78 @@
 {
-    "title": "PipesContextData",
-    "type": "object",
-    "description": "The serializable data passed from the orchestration process to the external process. This gets wrapped in a PipesContext.",
-    "properties": {
-        "asset_keys": {
-            "type": ["null", "array"],
-            "items": {
-                "type": "string"
-            }
-        },
-        "code_version_by_asset_key": {
-            "type": ["null", "object"],
-            "additionalProperties": {
-                "type": ["null", "string"]
-            }
-        },
-        "provenance_by_asset_key": {
-            "type": ["null", "object"],
-            "additionalProperties": {
-                "type": ["null", "object"],
-                "properties": {
-                    "code_version": {
-                        "type": "string"
-                    },
-                    "input_data_versions": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
-                    },
-                    "is_user_provided": {
-                        "type": "boolean"
-                    }
-                }
-            }
-        },
-        "partition_key": {
-            "type": ["null", "string"]
-        },
-        "partition_key_range": {
-            "type": ["null", "object"],
-            "properties": {
-                "start": {
-                    "type": "string"
-                },
-                "end": {
-                    "type": "string"
-                }
-            }
-        },
-        "partition_time_window": {
-            "type": ["null", "object"],
-            "properties": {
-                "start": {
-                    "type":"string"
-                },
-                "end": {
-                    "type": "string"
-                }
-            }
-        },
-        "run_id": {
-            "type": "string"
-        },
-        "job_name": {
-            "type": ["null", "string"]
-        },
-        "retry_number": {
-            "type": "integer"
-        },
-        "extras": {
-            "type": ["null", "object"]
-        }
+  "title": "PipesContextData",
+  "type": "object",
+  "description": "The serializable data passed from the orchestration process to the external process. This gets wrapped in a PipesContext.",
+  "properties": {
+    "asset_keys": {
+      "type": ["null", "array"],
+      "items": {
+        "type": "string"
+      }
     },
-    "required": ["run_id", "retry_number", "extras"],
-    "additionalProperties": false
+    "code_version_by_asset_key": {
+      "type": ["null", "object"],
+      "additionalProperties": {
+        "type": ["null", "string"]
+      }
+    },
+    "provenance_by_asset_key": {
+      "type": ["null", "object"],
+      "additionalProperties": {
+        "type": ["null", "object"],
+        "properties": {
+          "code_version": {
+            "type": "string"
+          },
+          "input_data_versions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "is_user_provided": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "partition_key": {
+      "type": ["null", "string"]
+    },
+    "partition_key_range": {
+      "type": ["null", "object"],
+      "properties": {
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        }
+      }
+    },
+    "partition_time_window": {
+      "type": ["null", "object"],
+      "properties": {
+        "start": {
+          "type": "string"
+        },
+        "end": {
+          "type": "string"
+        }
+      }
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "job_name": {
+      "type": ["null", "string"]
+    },
+    "retry_number": {
+      "type": "integer"
+    },
+    "extras": {
+      "type": ["null", "object"]
+    }
+  },
+  "required": ["run_id", "retry_number", "extras"],
+  "additionalProperties": false
 }

--- a/jsonschema/pipes/PipesContextData.schema.json
+++ b/jsonschema/pipes/PipesContextData.schema.json
@@ -1,0 +1,78 @@
+{
+    "title": "PipesContextData",
+    "type": "object",
+    "description": "The serializable data passed from the orchestration process to the external process. This gets wrapped in a PipesContext.",
+    "properties": {
+        "asset_keys": {
+            "type": ["null", "array"],
+            "items": {
+                "type": "string"
+            }
+        },
+        "code_version_by_asset_key": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+                "type": ["null", "string"]
+            }
+        },
+        "provenance_by_asset_key": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+                "type": ["null", "object"],
+                "properties": {
+                    "code_version": {
+                        "type": "string"
+                    },
+                    "input_data_versions": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "is_user_provided": {
+                        "type": "boolean"
+                    }
+                }
+            }
+        },
+        "partition_key": {
+            "type": ["null", "string"]
+        },
+        "partition_key_range": {
+            "type": ["null", "object"],
+            "properties": {
+                "start": {
+                    "type": "string"
+                },
+                "end": {
+                    "type": "string"
+                }
+            }
+        },
+        "partition_time_window": {
+            "type": ["null", "object"],
+            "properties": {
+                "start": {
+                    "type":"string"
+                },
+                "end": {
+                    "type": "string"
+                }
+            }
+        },
+        "run_id": {
+            "type": "string"
+        },
+        "job_name": {
+            "type": ["null", "string"]
+        },
+        "retry_number": {
+            "type": "integer"
+        },
+        "extras": {
+            "type": ["null", "object"]
+        }
+    },
+    "required": ["run_id", "retry_number", "extras"],
+    "additionalProperties": false
+}

--- a/jsonschema/pipes/PipesException.schema.json
+++ b/jsonschema/pipes/PipesException.schema.json
@@ -1,0 +1,28 @@
+{
+    "title": "PipesException",
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string"
+      },
+      "stack": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": ["null", "string"],
+        "description": "class name of Exception object"
+      },
+      "cause": {
+        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+        "description": "exception that explicitly led to this exception"
+      },
+      "context": {
+        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+        "$ref": "#",
+        "description": "exception that being handled when this exception was raised"
+      }
+    }
+  }

--- a/jsonschema/pipes/PipesException.schema.json
+++ b/jsonschema/pipes/PipesException.schema.json
@@ -1,28 +1,28 @@
 {
-    "title": "PipesException",
-    "type": "object",
-    "properties": {
-      "message": {
+  "title": "PipesException",
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    },
+    "stack": {
+      "type": "array",
+      "items": {
         "type": "string"
-      },
-      "stack": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": ["null", "string"],
-        "description": "class name of Exception object"
-      },
-      "cause": {
-        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
-        "description": "exception that explicitly led to this exception"
-      },
-      "context": {
-        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
-        "$ref": "#",
-        "description": "exception that being handled when this exception was raised"
       }
+    },
+    "name": {
+      "type": ["null", "string"],
+      "description": "class name of Exception object"
+    },
+    "cause": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+      "description": "exception that explicitly led to this exception"
+    },
+    "context": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+      "$ref": "#",
+      "description": "exception that being handled when this exception was raised"
     }
   }
+}

--- a/jsonschema/pipes/PipesLog.schema.json
+++ b/jsonschema/pipes/PipesLog.schema.json
@@ -1,0 +1,28 @@
+{
+    "title": "PipesException",
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string"
+      },
+      "stack": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": ["null", "string"],
+        "description": "class name of Exception object"
+      },
+      "cause": {
+        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+        "description": "exception that explicitly led to this exception"
+      },
+      "context": {
+        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+        "$ref": "#",
+        "description": "exception that being handled when this exception was raised"
+      }
+    }
+  }

--- a/jsonschema/pipes/PipesLog.schema.json
+++ b/jsonschema/pipes/PipesLog.schema.json
@@ -1,28 +1,28 @@
 {
-    "title": "PipesException",
-    "type": "object",
-    "properties": {
-      "message": {
+  "title": "PipesException",
+  "type": "object",
+  "properties": {
+    "message": {
+      "type": "string"
+    },
+    "stack": {
+      "type": "array",
+      "items": {
         "type": "string"
-      },
-      "stack": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": ["null", "string"],
-        "description": "class name of Exception object"
-      },
-      "cause": {
-        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
-        "description": "exception that explicitly led to this exception"
-      },
-      "context": {
-        "oneOf": [{ "type": "null" }, { "$ref": "#" }],
-        "$ref": "#",
-        "description": "exception that being handled when this exception was raised"
       }
+    },
+    "name": {
+      "type": ["null", "string"],
+      "description": "class name of Exception object"
+    },
+    "cause": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+      "description": "exception that explicitly led to this exception"
+    },
+    "context": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#" }],
+      "$ref": "#",
+      "description": "exception that being handled when this exception was raised"
     }
   }
+}

--- a/jsonschema/pipes/PipesMessage.schema.json
+++ b/jsonschema/pipes/PipesMessage.schema.json
@@ -1,34 +1,27 @@
 {
-    "title": "PipesMessage",
-    "type": "object",
-    "properties": {
-        "__dagster_pipes_version": {
-            "type": "string",
-            "description": "The version of the Dagster Pipes protocol"
-        },
-        "method": {
-            "enum": [
-                "opened",
-                "closed",
-                "log",
-                "report_asset_materialization",
-                "report_asset_check",
-                "report_custom_message"
-            ],
-            "description": "Event type"
-        },
-        "params": {
-            "type": [
-                "object",
-                "null"
-            ],
-            "description": "Event parameters"
-        }
+  "title": "PipesMessage",
+  "type": "object",
+  "properties": {
+    "__dagster_pipes_version": {
+      "type": "string",
+      "description": "The version of the Dagster Pipes protocol"
     },
-    "required": [
-        "__dagster_pipes_version",
-        "method",
-        "params"
-    ],
-    "additionalProperties": false
+    "method": {
+      "enum": [
+        "opened",
+        "closed",
+        "log",
+        "report_asset_materialization",
+        "report_asset_check",
+        "report_custom_message"
+      ],
+      "description": "Event type"
+    },
+    "params": {
+      "type": ["object", "null"],
+      "description": "Event parameters"
+    }
+  },
+  "required": ["__dagster_pipes_version", "method", "params"],
+  "additionalProperties": false
 }

--- a/jsonschema/pipes/PipesMessage.schema.json
+++ b/jsonschema/pipes/PipesMessage.schema.json
@@ -1,0 +1,34 @@
+{
+    "title": "PipesMessage",
+    "type": "object",
+    "properties": {
+        "__dagster_pipes_version": {
+            "type": "string",
+            "description": "The version of the Dagster Pipes protocol"
+        },
+        "method": {
+            "enum": [
+                "opened",
+                "closed",
+                "log",
+                "report_asset_materialization",
+                "report_asset_check",
+                "report_custom_message"
+            ],
+            "description": "Event type"
+        },
+        "params": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "description": "Event parameters"
+        }
+    },
+    "required": [
+        "__dagster_pipes_version",
+        "method",
+        "params"
+    ],
+    "additionalProperties": false
+}

--- a/jsonschema/pipes/PipesMetadataValue.schema.json
+++ b/jsonschema/pipes/PipesMetadataValue.schema.json
@@ -1,0 +1,42 @@
+{
+    "title": "PipesMetadataValue",
+    "type": "object",
+    "properties": {
+        "type": {
+            "enum": [
+                "__infer__",
+                "text",
+                "url",
+                "path",
+                "notebook",
+                "json",
+                "md",
+                "float",
+                "int",
+                "bool",
+                "dagster_run",
+                "asset",
+                "null",
+                "job",
+                "timestamp"
+            ]
+        },
+        "raw_value": {
+            "anyOf": [
+                {"type": "integer"},
+                {"type": "number"},
+                {"type": "string"},
+                {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                {
+                    "type": "array",
+                    "items": {}
+                },
+                {"type": "boolean"},
+                {"type": "null"}
+            ]
+        }
+    }
+}

--- a/jsonschema/pipes/PipesMetadataValue.schema.json
+++ b/jsonschema/pipes/PipesMetadataValue.schema.json
@@ -1,42 +1,42 @@
 {
-    "title": "PipesMetadataValue",
-    "type": "object",
-    "properties": {
-        "type": {
-            "enum": [
-                "__infer__",
-                "text",
-                "url",
-                "path",
-                "notebook",
-                "json",
-                "md",
-                "float",
-                "int",
-                "bool",
-                "dagster_run",
-                "asset",
-                "null",
-                "job",
-                "timestamp"
-            ]
+  "title": "PipesMetadataValue",
+  "type": "object",
+  "properties": {
+    "type": {
+      "enum": [
+        "__infer__",
+        "text",
+        "url",
+        "path",
+        "notebook",
+        "json",
+        "md",
+        "float",
+        "int",
+        "bool",
+        "dagster_run",
+        "asset",
+        "null",
+        "job",
+        "timestamp"
+      ]
+    },
+    "raw_value": {
+      "anyOf": [
+        { "type": "integer" },
+        { "type": "number" },
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": true
         },
-        "raw_value": {
-            "anyOf": [
-                {"type": "integer"},
-                {"type": "number"},
-                {"type": "string"},
-                {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                {
-                    "type": "array",
-                    "items": {}
-                },
-                {"type": "boolean"},
-                {"type": "null"}
-            ]
-        }
+        {
+          "type": "array",
+          "items": {}
+        },
+        { "type": "boolean" },
+        { "type": "null" }
+      ]
     }
+  }
 }

--- a/quicktype.sh
+++ b/quicktype.sh
@@ -1,0 +1,4 @@
+#!bash
+
+printf -- '%s\0' jsonschema/pipes/*.schema.json | xargs -0 \
+    quicktype --visibility public -s schema -l rust --derive-debug -o src/types.rs 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,203 @@
+// Example code that deserializes and serializes the model.
+// extern crate serde;
+// #[macro_use]
+// extern crate serde_derive;
+// extern crate serde_json;
+//
+// use generated_module::PipesContextData;
+//
+// fn main() {
+//     let json = r#"{"answer": 42}"#;
+//     let model: PipesContextData = serde_json::from_str(&json).unwrap();
+// }
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The serializable data passed from the orchestration process to the external process. This
+/// gets wrapped in a PipesContext.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipesContextData {
+    pub asset_keys: Option<Vec<String>>,
+
+    pub code_version_by_asset_key: Option<HashMap<String, Option<String>>>,
+
+    pub extras: Option<HashMap<String, Option<serde_json::Value>>>,
+
+    pub job_name: Option<String>,
+
+    pub partition_key: Option<String>,
+
+    pub partition_key_range: Option<PartitionKeyRange>,
+
+    pub partition_time_window: Option<PartitionTimeWindow>,
+
+    pub provenance_by_asset_key: Option<HashMap<String, Option<ProvenanceByAssetKey>>>,
+
+    pub retry_number: i64,
+
+    pub run_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PartitionKeyRange {
+    pub end: Option<String>,
+
+    pub start: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PartitionTimeWindow {
+    pub end: Option<String>,
+
+    pub start: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProvenanceByAssetKey {
+    pub code_version: Option<String>,
+
+    pub input_data_versions: Option<HashMap<String, String>>,
+
+    pub is_user_provided: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipesException {
+    /// exception that explicitly led to this exception
+    pub cause: Box<Option<PipesExceptionClass>>,
+
+    /// exception that being handled when this exception was raised
+    pub context: Box<Option<ContextClass>>,
+
+    pub message: Option<String>,
+
+    /// class name of Exception object
+    pub name: Option<String>,
+
+    pub stack: Option<Vec<String>>,
+}
+
+/// exception that being handled when this exception was raised
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ContextClass {
+    /// exception that explicitly led to this exception
+    pub cause: Box<Option<PipesExceptionClass>>,
+
+    /// exception that being handled when this exception was raised
+    pub context: Box<Option<ContextClass>>,
+
+    pub message: Option<String>,
+
+    /// class name of Exception object
+    pub name: Option<String>,
+
+    pub stack: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipesExceptionClass {
+    /// exception that explicitly led to this exception
+    pub cause: Box<Option<PipesExceptionClass>>,
+
+    /// exception that being handled when this exception was raised
+    pub context: Box<Option<ContextClass>>,
+
+    pub message: Option<String>,
+
+    /// class name of Exception object
+    pub name: Option<String>,
+
+    pub stack: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipesMessage {
+    /// The version of the Dagster Pipes protocol
+    #[serde(rename = "__dagster_pipes_version")]
+    pub dagster_pipes_version: String,
+
+    /// Event type
+    pub method: Method,
+
+    /// Event parameters
+    pub params: Option<HashMap<String, Option<serde_json::Value>>>,
+}
+
+/// Event type
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Method {
+    Closed,
+
+    Log,
+
+    Opened,
+
+    #[serde(rename = "report_asset_check")]
+    ReportAssetCheck,
+
+    #[serde(rename = "report_asset_materialization")]
+    ReportAssetMaterialization,
+
+    #[serde(rename = "report_custom_message")]
+    ReportCustomMessage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PipesMetadataValue {
+    pub raw_value: Option<RawValue>,
+
+    #[serde(rename = "type")]
+    pub pipes_metadata_value_type: Option<Type>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Type {
+    Asset,
+
+    Bool,
+
+    #[serde(rename = "dagster_run")]
+    DagsterRun,
+
+    Float,
+
+    #[serde(rename = "__infer__")]
+    Infer,
+
+    Int,
+
+    Job,
+
+    Json,
+
+    Md,
+
+    Notebook,
+
+    Null,
+
+    Path,
+
+    Text,
+
+    Timestamp,
+
+    Url,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RawValue {
+    AnythingArray(Vec<Option<serde_json::Value>>),
+
+    AnythingMap(HashMap<String, Option<serde_json::Value>>),
+
+    Bool(bool),
+
+    Double(f64),
+
+    String(String),
+}


### PR DESCRIPTION
Contributes to https://github.com/cmpadden/dagster-pipes-rust/issues/5

The jsonschema definitions are taken from the jsonschema definitions [here](https://github.com/dagster-io/dagster-pipes-java/tree/main/jsonschema/pipes) with 2 changes:
* `PipesContext` was renamed to `PipesContextData` to fit the current implementation
* The additional [properties](https://github.com/dagster-io/dagster-pipes-java/blob/main/jsonschema/pipes/PipesMessage.schema.json#L25-L27) from the `PipesMessage` was removed because it created an extra level of nesting in the Rust struct that I don't think should be there