### PR TITLE
🥅 Handle errors from Loader types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [UNRELEASED]
+- (pull/9) Handle errors for `ParamsLoader` and `ContextLoader` implementations
+
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -202,6 +203,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0"
 flate2 = "1"
+thiserror = "2.0.3"
 
 [dev-dependencies]
 tempfile = "3.14.0"

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.lock
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "flate2",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -143,6 +144,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -14,4 +14,5 @@ fn main() {
         AssetCheckSeverity::Warn,
         json!({"quality": {"raw_value": 5, "type": "int"}}),
     );
+    Ok(())
 }

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -1,8 +1,8 @@
-use dagster_pipes_rust::{open_dagster_pipes, AssetCheckSeverity};
+use dagster_pipes_rust::{open_dagster_pipes, AssetCheckSeverity, DagsterPipesError};
 use serde_json::json;
 
-fn main() {
-    let mut context = open_dagster_pipes();
+fn main() -> Result<(), DagsterPipesError> {
+    let mut context = open_dagster_pipes()?;
     // See supported metadata types here:
     // https://github.com/dagster-io/dagster/blob/master/python_modules/dagster/dagster/_core/pipes/context.py#L133
     let metadata = json!({"row_count": {"raw_value": 100, "type": "int"}});

--- a/quicktype.sh
+++ b/quicktype.sh
@@ -1,4 +1,4 @@
 #!bash
 
 printf -- '%s\0' jsonschema/pipes/*.schema.json | xargs -0 \
-    quicktype --visibility public -s schema -l rust --derive-debug -o src/types.rs 
+    quicktype -s schema -l rust --visibility public --derive-debug --derive-partial-eq -o src/types.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,12 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
 
+use context_loader::PayloadErrorKind;
+use params_loader::ParamsError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
+use thiserror::Error;
 
 use crate::context_loader::PipesContextLoader;
 use crate::context_loader::PipesDefaultContextLoader;
@@ -93,27 +96,60 @@ struct PipesMessagesParams {
     stdio: Option<String>, // stderr | stdout (unsupported)
 }
 
+#[derive(Debug, Error)]
+#[error("dagster pipes failure:\n{0}")]
+#[non_exhaustive]
+pub struct DagsterPipesError(#[from] pub DagsterPipesErrorKind);
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+#[non_exhaustive]
+pub enum DagsterPipesErrorKind {
+    #[error("failed to load params:\n{0}")]
+    #[non_exhaustive]
+    ParamsLoader(#[from] ParamsError),
+
+    #[error("failed to load context:\n{0}")]
+    #[non_exhaustive]
+    ContextLoader(#[from] PayloadErrorKind),
+}
+
+impl From<ParamsError> for DagsterPipesError {
+    fn from(value: ParamsError) -> Self {
+        DagsterPipesError(DagsterPipesErrorKind::ParamsLoader(value))
+    }
+}
+
+impl From<PayloadErrorKind> for DagsterPipesError {
+    fn from(value: PayloadErrorKind) -> Self {
+        DagsterPipesError(DagsterPipesErrorKind::ContextLoader(value))
+    }
+}
+
 // partial translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L798-L838
-pub fn open_dagster_pipes() -> PipesContext {
+pub fn open_dagster_pipes() -> Result<PipesContext, DagsterPipesError> {
     let params_loader = PipesEnvVarParamsLoader::new();
     let context_loader = PipesDefaultContextLoader::new();
 
-    let context_params = params_loader.load_context_params();
-    let message_params = params_loader.load_message_params();
+    let context_params = params_loader.load_context_params()?;
+    let context_data = context_loader.load_context(context_params)?;
 
+
+    let message_params = params_loader.load_message_params()?;
     // TODO: Refactor into MessageWriter impl
     let path = match &message_params["path"] {
         Value::String(string) => string.clone(),
         _ => panic!("Expected message \"path\" in bootstrap payload"),
     };
 
+
     //if stdio != "stderr" {
     //    panic!("only stderr supported for dagster pipes messages")
     //}
 
-    PipesContext {
-        data: context_loader.load_context(context_params),
+    Ok(PipesContext {
+        data: context_data,
         writer: PipesFileMessageWriter { path },
-    }
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,33 +97,15 @@ struct PipesMessagesParams {
 }
 
 #[derive(Debug, Error)]
-#[error("dagster pipes failure:\n{0}")]
 #[non_exhaustive]
-pub struct DagsterPipesError(#[from] pub DagsterPipesErrorKind);
-
-#[derive(Debug, Error)]
-#[error(transparent)]
-#[non_exhaustive]
-pub enum DagsterPipesErrorKind {
-    #[error("failed to load params:\n{0}")]
+pub enum DagsterPipesError {
+    #[error("dagster pipes failed to load params: {0}")]
     #[non_exhaustive]
     ParamsLoader(#[from] ParamsError),
 
-    #[error("failed to load context:\n{0}")]
+    #[error("dagster pipes failed to load context: {0}")]
     #[non_exhaustive]
     ContextLoader(#[from] PayloadErrorKind),
-}
-
-impl From<ParamsError> for DagsterPipesError {
-    fn from(value: ParamsError) -> Self {
-        DagsterPipesError(DagsterPipesErrorKind::ParamsLoader(value))
-    }
-}
-
-impl From<PayloadErrorKind> for DagsterPipesError {
-    fn from(value: PayloadErrorKind) -> Self {
-        DagsterPipesError(DagsterPipesErrorKind::ContextLoader(value))
-    }
 }
 
 // partial translation of
@@ -135,14 +117,12 @@ pub fn open_dagster_pipes() -> Result<PipesContext, DagsterPipesError> {
     let context_params = params_loader.load_context_params()?;
     let context_data = context_loader.load_context(context_params)?;
 
-
     let message_params = params_loader.load_message_params()?;
     // TODO: Refactor into MessageWriter impl
     let path = match &message_params["path"] {
         Value::String(string) => string.clone(),
         _ => panic!("Expected message \"path\" in bootstrap payload"),
     };
-
 
     //if stdio != "stderr" {
     //    panic!("only stderr supported for dagster pipes messages")

--- a/src/params_loader.rs
+++ b/src/params_loader.rs
@@ -2,7 +2,9 @@ use base64::prelude::*;
 use flate2::read::ZlibDecoder;
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
+use std::fmt;
 use std::io::Read;
+use thiserror::Error;
 
 const DAGSTER_PIPES_CONTEXT_ENV_VAR: &str = "DAGSTER_PIPES_CONTEXT";
 const DAGSTER_PIPES_MESSAGES_ENV_VAR: &str = "DAGSTER_PIPES_MESSAGES";
@@ -15,9 +17,82 @@ pub trait PipesParamsLoader {
     /// to create a PipesContext or should instead return a mock.
     fn is_dagster_pipes_process(&self) -> bool;
     /// Load params passed by the orchestration-side context injector.
-    fn load_context_params(&self) -> Map<String, Value>;
+    fn load_context_params(&self) -> Result<Map<String, Value>, ParamsError>;
     /// Load params passed by the orchestration-side message reader.
-    fn load_message_params(&self) -> Map<String, Value>;
+    fn load_message_params(&self) -> Result<Map<String, Value>, ParamsError>;
+}
+
+#[derive(Debug, Error)]
+#[error("{} parameter \"{}\" is {}", .origin, .param, .source)]
+pub struct ParamsError {
+    pub param: String,
+    pub origin: ParamOrigin,
+    pub source: ParamsErrorKind,
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ParamOrigin {
+    Cli,
+    EnvVar,
+}
+
+impl fmt::Display for ParamOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cli => write!(f, "cli"),
+            Self::EnvVar => write!(f, "env var"),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ParamsErrorKind {
+    #[error("not present")]
+    #[non_exhaustive]
+    NotPresent,
+
+    #[error("invalid")]
+    #[non_exhaustive]
+    Invalid {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl From<std::env::VarError> for ParamsErrorKind {
+    fn from(value: std::env::VarError) -> Self {
+        match value {
+            std::env::VarError::NotPresent => Self::NotPresent,
+            std::env::VarError::NotUnicode(_) => Self::Invalid {
+                source: Box::new(value),
+            },
+        }
+    }
+}
+
+impl From<base64::DecodeError> for ParamsErrorKind {
+    fn from(value: base64::DecodeError) -> Self {
+        Self::Invalid {
+            source: Box::new(value),
+        }
+    }
+}
+
+impl From<std::io::Error> for ParamsErrorKind {
+    fn from(value: std::io::Error) -> Self {
+        Self::Invalid {
+            source: Box::new(value),
+        }
+    }
+}
+
+impl From<serde_json::Error> for ParamsErrorKind {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Invalid {
+            source: Box::new(value),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -34,26 +109,46 @@ impl PipesParamsLoader for PipesEnvVarParamsLoader {
         std::env::var(DAGSTER_PIPES_CONTEXT_ENV_VAR).is_ok()
     }
 
-    fn load_context_params(&self) -> Map<String, Value> {
-        let param = std::env::var(DAGSTER_PIPES_CONTEXT_ENV_VAR).unwrap();
-        decode_env_var(&param)
+    fn load_context_params(&self) -> Result<Map<String, Value>, ParamsError> {
+        let param = std::env::var(DAGSTER_PIPES_CONTEXT_ENV_VAR).map_err(|source| ParamsError {
+            param: DAGSTER_PIPES_CONTEXT_ENV_VAR.to_string(),
+            origin: ParamOrigin::Cli,
+            source: ParamsErrorKind::from(source),
+        })?;
+        let result = decode_env_var(&param).map_err(|source| ParamsError {
+            param: DAGSTER_PIPES_CONTEXT_ENV_VAR.to_string(),
+            origin: ParamOrigin::Cli,
+            source,
+        })?;
+        Ok(result)
     }
 
-    fn load_message_params(&self) -> Map<String, Value> {
-        let param = std::env::var(DAGSTER_PIPES_MESSAGES_ENV_VAR).unwrap();
-        decode_env_var(&param)
+    fn load_message_params(&self) -> Result<Map<String, Value>, ParamsError> {
+        let param =
+            std::env::var(DAGSTER_PIPES_MESSAGES_ENV_VAR).map_err(|source| ParamsError {
+                param: DAGSTER_PIPES_MESSAGES_ENV_VAR.to_string(),
+                origin: ParamOrigin::Cli,
+                source: ParamsErrorKind::from(source),
+            })?;
+        let result = decode_env_var(&param).map_err(|source| ParamsError {
+            param: DAGSTER_PIPES_MESSAGES_ENV_VAR.to_string(),
+            origin: ParamOrigin::Cli,
+            source,
+        })?;
+        Ok(result)
     }
 }
 
 // translation of
 // https://github.com/dagster-io/dagster/blob/258d9ca0db/python_modules/dagster-pipes/dagster_pipes/__init__.py#L354-L367
-fn decode_env_var<T>(param: &str) -> T
+fn decode_env_var<T>(param: &str) -> Result<T, ParamsErrorKind>
 where
     T: DeserializeOwned,
 {
-    let zlib_compressed_slice = BASE64_STANDARD.decode(param).unwrap();
+    let zlib_compressed_slice = BASE64_STANDARD.decode(param)?;
     let mut decoder = ZlibDecoder::new(&zlib_compressed_slice[..]);
     let mut json_str = String::new();
-    decoder.read_to_string(&mut json_str).unwrap();
-    serde_json::from_str(&json_str).unwrap()
+    decoder.read_to_string(&mut json_str)?;
+    let decoded = serde_json::from_str(&json_str)?;
+    Ok(decoded)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,12 +11,12 @@
 //     let model: PipesContextData = serde_json::from_str(&json).unwrap();
 // }
 
-use serde::{Deserialize, Serialize};
+use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 
 /// The serializable data passed from the orchestration process to the external process. This
 /// gets wrapped in a PipesContext.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PipesContextData {
     pub asset_keys: Option<Vec<String>>,
 
@@ -39,21 +39,21 @@ pub struct PipesContextData {
     pub run_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PartitionKeyRange {
     pub end: Option<String>,
 
     pub start: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PartitionTimeWindow {
     pub end: Option<String>,
 
     pub start: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProvenanceByAssetKey {
     pub code_version: Option<String>,
 
@@ -62,7 +62,7 @@ pub struct ProvenanceByAssetKey {
     pub is_user_provided: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PipesException {
     /// exception that explicitly led to this exception
     pub cause: Box<Option<PipesExceptionClass>>,
@@ -79,7 +79,7 @@ pub struct PipesException {
 }
 
 /// exception that being handled when this exception was raised
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ContextClass {
     /// exception that explicitly led to this exception
     pub cause: Box<Option<PipesExceptionClass>>,
@@ -95,7 +95,7 @@ pub struct ContextClass {
     pub stack: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PipesExceptionClass {
     /// exception that explicitly led to this exception
     pub cause: Box<Option<PipesExceptionClass>>,
@@ -111,7 +111,7 @@ pub struct PipesExceptionClass {
     pub stack: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PipesMessage {
     /// The version of the Dagster Pipes protocol
     #[serde(rename = "__dagster_pipes_version")]
@@ -125,7 +125,7 @@ pub struct PipesMessage {
 }
 
 /// Event type
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Method {
     Closed,
@@ -144,7 +144,7 @@ pub enum Method {
     ReportCustomMessage,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PipesMetadataValue {
     pub raw_value: Option<RawValue>,
 
@@ -152,7 +152,7 @@ pub struct PipesMetadataValue {
     pub pipes_metadata_value_type: Option<Type>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Type {
     Asset,
@@ -188,7 +188,7 @@ pub enum Type {
     Url,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RawValue {
     AnythingArray(Vec<Option<serde_json::Value>>),


### PR DESCRIPTION
The code so far relies on `.unwrap`, `.expect` or `panic!`. These are fine for prototypes, but less ideal for a library for others to consume. 

In this PR, errors from the methods of the Loader classes (`PipesDefaultContextLoader` and `PipesEnvVarParamsLoader`) are modelled in a layered fashion, and surfaced up to a top-level `DagsterPipesError` type, using the popular `thiserror` crate to minimize boilerplate.

This is my first time modelling errors in Rust, and is based on various iterations following various blog posts on the subject, but primarily influenced by this [article](https://gist.github.com/quad/a8a7cc87d1401004c6a8973947f20365) and its accompanying links. Feedback is welcome!

> [!NOTE]
> To be reviewed after #3 