### PR TITLE
Add a python integration test for a rust subprocess job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
+
+.vscode

--- a/example-dagster-pipes-rust-project/example_dagster_pipes_rust_project_tests/test_subprocess.py
+++ b/example-dagster-pipes-rust-project/example_dagster_pipes_rust_project_tests/test_subprocess.py
@@ -1,0 +1,51 @@
+import shutil
+
+from dagster import (
+    asset,
+    AssetCheckSpec,
+    AssetExecutionContext,
+    file_relative_path,
+    materialize_to_memory,
+    MaterializeResult,
+    PipesSubprocessClient,
+    PipesEnvContextInjector,
+)
+
+
+def test_example_rust_subprocess_asset():
+    @asset(
+        check_specs=[
+            AssetCheckSpec(
+                name="example_rust_subprocess_check",
+                asset="example_rust_subprocess_asset",
+            )
+        ],
+    )
+    def example_rust_subprocess_asset(
+        context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
+    ) -> MaterializeResult:
+        """Demonstrates running Rust binary in a subprocess."""
+        cmd = [shutil.which("cargo"), "run"]
+        cwd = file_relative_path(__file__, "../rust_processing_jobs")
+        return pipes_subprocess_client.run(
+            command=cmd,
+            cwd=cwd,
+            context=context,
+        ).get_materialize_result()
+
+    result = materialize_to_memory(
+        assets=[example_rust_subprocess_asset],
+        resources={
+            "pipes_subprocess_client": PipesSubprocessClient(
+                context_injector=PipesEnvContextInjector(),
+            )
+        },
+    )
+    assert result.success
+    assert result.get_asset_materialization_events()[0].asset_key.path == [
+        "example_rust_subprocess_asset"
+    ]
+    assert (
+        result.get_asset_check_evaluations()[0].asset_check_key.name
+        == "example_rust_subprocess_check"
+    )

--- a/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
+++ b/example-dagster-pipes-rust-project/rust_processing_jobs/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), DagsterPipesError> {
         "example_rust_subprocess_check",
         true,
         "example_rust_subprocess_asset",
-        AssetCheckSeverity::Warn,
+        &AssetCheckSeverity::Warn,
         json!({"quality": {"raw_value": 5, "type": "int"}}),
     );
     Ok(())


### PR DESCRIPTION
## Summary & Motivation

This contributes to https://github.com/cmpadden/dagster-pipes-rust/issues/19. Adds a python test in the example project. Also makes a small update to the rust processing job to make the test pass.

## How I Tested These Changes

Run the test locally with:
```
cd example-dagster-pipes-rust-project
pytest example_dagster_pipes_rust_project_tests
```

## Changelog

N/a. No public facing change