### PR TITLE
Adds basic ruff setup

### DIFF
--- a/example-dagster-pipes-rust-project/Makefile
+++ b/example-dagster-pipes-rust-project/Makefile
@@ -1,0 +1,3 @@
+ruff:
+	-ruff check --fix .
+	ruff format .

--- a/example-dagster-pipes-rust-project/pyproject.toml
+++ b/example-dagster-pipes-rust-project/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 dev = [
     "dagster-webserver", 
     "pytest",
+    "ruff",
 ]
 
 [build-system]

--- a/example-dagster-pipes-rust-project/setup.py
+++ b/example-dagster-pipes-rust-project/setup.py
@@ -3,9 +3,6 @@ from setuptools import find_packages, setup
 setup(
     name="example_dagster_pipes_rust_project",
     packages=find_packages(exclude=["example_dagster_pipes_rust_project_tests"]),
-    install_requires=[
-        "dagster",
-        "dagster-cloud"
-    ],
-    extras_require={"dev": ["dagster-webserver", "pytest"]},
+    install_requires=["dagster", "dagster-cloud"],
+    extras_require={"dev": ["dagster-webserver", "pytest", "ruff"]},
 )


### PR DESCRIPTION
## Summary & Motivation

This adds a simple makefile and default ruff setup for formatting & linting python code

## How I Tested These Changes

```
cd example-dagster-pipes-rust-project
make ruff
```

## Changelog

n/a
